### PR TITLE
bpa and challan receipt fix

### DIFF
--- a/configs/pdf-service/data-config/challan-notice.json
+++ b/configs/pdf-service/data-config/challan-notice.json
@@ -218,7 +218,7 @@
               {
                 "variable": "violationDate",
                 "value": {
-                  "path": "$.challans[0].documents[0].auditDetails.lastModifiedTime"
+                  "path": "$.challans[0].auditDetails.lastModifiedTime"
                 },
                 "type": "date"
               },
@@ -238,6 +238,17 @@
                 "variable": "offenceCategoryName",
                 "value": {
                   "path": "$.challans[0].offenceCategoryName"
+                }
+              },
+              {
+                "variable": "longitude",
+                "value": {
+                  "path": "$.challans[0].additionalDetail.longitude"
+                }
+              },{
+                "variable": "latitude",
+                "value": {
+                  "path": "$.challans[0].additionalDetail.latitude"
                 }
               },
               {
@@ -262,7 +273,7 @@
               {
                 "variable": "challanFine",
                 "value": {
-                  "path": "$.challans[0].additionalDetail.amount[?(@.taxHeadCode == 'CH.CHALLAN_FINE')].amount"
+                  "path": "$.challans[0].additionalDetail.calculation.taxHeadEstimates[?(@.taxHeadCode == 'CH.CHALLAN_FINE')].estimateAmount"
                 }
               },
 
@@ -550,6 +561,42 @@
                 }
               },
               {
+                "variable": "challan_notice_1",
+                "value": {
+                  "path": "PDF_STATIC_LABEL_CONSOLIDATED_RECEIPT_CHALLAN_NOTICE_1"
+                },
+                "type": "label",
+                "localisation": {
+                  "required": true,
+                  "prefix": null,
+                  "module": "rainmaker-common"
+                }
+              },
+              {
+                "variable": "challan_notice_2",
+                "value": {
+                  "path": "PDF_STATIC_LABEL_CONSOLIDATED_RECEIPT_CHALLAN_NOTICE_2"
+                },
+                "type": "label",
+                "localisation": {
+                  "required": true,
+                  "prefix": null,
+                  "module": "rainmaker-common"
+                }
+              },
+              {
+                "variable": "challan_notice_3",
+                "value": {
+                  "path": "PDF_STATIC_LABEL_CONSOLIDATED_RECEIPT_CHALLAN_NOTICE_3"
+                },
+                "type": "label",
+                "localisation": {
+                  "required": true,
+                  "prefix": null,
+                  "module": "rainmaker-common"
+                }
+              },
+              {
                 "variable": "disclamer",
                 "value": {
                   "path": "PDF_STATIC_LABEL_CONSOLIDATED_RECEIPT_DISCLAIMER"
@@ -667,7 +714,7 @@
               },
               {
                 "variable": "TotalChallanAmount",
-                "formula": "{{challanFine}}>=0?{{challanFine}}+{{challanAmount}}:0"
+                "formula": "{{challanFine}}>{{challanAmount}}?{{challanFine}}:{{challanAmount}}"
               },
               {
                 "variable": "excessAmountPaid",

--- a/configs/pdf-service/data-config/challangeneration-receipt.json
+++ b/configs/pdf-service/data-config/challangeneration-receipt.json
@@ -94,7 +94,7 @@
               {
                 "variable": "challanFee",
                 "value": {
-                  "path": "$.paymentDetails[0].bill.billDetails[0].billAccountDetails[?(@.taxHeadCode=='CH.CHALLAN_FINE')].adjustedAmount"
+                  "path": "$.challan.challans[0].additionalDetail.calculation.taxHeadEstimates[?(@.taxHeadCode=='CH.CHALLAN_FINE')].estimateAmount"
                 }
               },
               {
@@ -588,7 +588,7 @@
               },
               {
                 "variable": "TotalChallanAmount",
-                "formula": "{{challanFee}}>=0?{{challanFee}}+{{challanAmount}}:0"
+                "formula": "{{challanFee}}>{{challanAmount}}?{{challanFee}}:{{challanAmount}}"
               },
               {
                 "variable": "excessAmountPaid",

--- a/configs/pdf-service/data-config/chb-permissionletter.json
+++ b/configs/pdf-service/data-config/chb-permissionletter.json
@@ -20,6 +20,18 @@
                 }
               },
               {
+                "variable": "applicantName",
+                "value": {
+                  "path": "$.hallsBookingApplication[0].applicantDetail.applicantName"
+                }
+              },
+              {
+                "variable": "applicantMobileNo",
+                "value": {
+                  "path": "$.hallsBookingApplication[0].applicantDetail.applicantMobileNo"
+                }
+              },
+              {
                 "variable": "designation",
                 "value": {
                   "path": "$.additionalDetails.designation"

--- a/configs/pdf-service/data-config/chbservice-receipt.json
+++ b/configs/pdf-service/data-config/chbservice-receipt.json
@@ -228,6 +228,18 @@
                 }
               },
               {
+                "variable": "applicantName",
+                "value": {
+                  "path": "$.hallsBookingApplication[0].applicantDetail.applicantName"
+                }
+              },
+              {
+                "variable": "applicantMobileNo",
+                "value": {
+                  "path": "$.hallsBookingApplication[0].applicantDetail.applicantMobileNo"
+                }
+              },
+              {
                 "variable": "fromPeriod",
                 "value": {
                   "path": "$.paymentDetails[0].bill.billDetails[0].fromPeriod"

--- a/configs/pdf-service/format-config/bpa-obps-receipt.json
+++ b/configs/pdf-service/format-config/bpa-obps-receipt.json
@@ -225,7 +225,7 @@
                 "text": "Amount (In ₹)",
                 "style": "receipt-fee-label",
                 "alignment": "right",
-                "margin": [0, 0, 35, 0]
+                "margin": [0, 0, 4, 0]
               }
             ],
             [
@@ -303,11 +303,12 @@
             "alignment": "left"
           },
           {
-            "text": [
-              { "text": "{{ulbType}} {{logo-header}}", "bold": true }
+            "ul": [
+              { "text": "{{ulbType}}", "bold": true,"listType": "none" },
+              { "text": "{{logo-header}}", "bold": true,"listType": "none" }
             ],
             "alignment": "right",
-            "margin": [0, 0, -10, 0]
+            "margin": [0, 0, -2, 0]
           }
         ]
       },
@@ -391,7 +392,7 @@
         "fontSize": 10,
         "color": "#000000",
         "alignment": "right",
-        "margin": [0, 6, 35, 6]
+        "margin": [0, 6, 4, 6]
       },
       "receipt-total-label": {
         "fontSize": 10,
@@ -404,7 +405,7 @@
         "color": "#000000",
         "bold": true,
         "alignment": "right",
-        "margin": [0, 6, 35, 6]
+        "margin": [0, 6, 4, 6]
       },
       "receipt-approver": {
         "fontSize": 10,

--- a/configs/pdf-service/format-config/bpa-receipt.json
+++ b/configs/pdf-service/format-config/bpa-receipt.json
@@ -225,7 +225,7 @@
                 "text": "Amount (In ₹)",
                 "style": "receipt-fee-label",
                 "alignment": "right",
-                "margin": [0, 0, 35, 0]
+                "margin": [0, 0, 4, 0]
               }
             ],
             [
@@ -280,11 +280,12 @@
             "alignment": "left"
           },
           {
-            "text": [
-              { "text": "{{ulbType}} , {{logo-header}}", "bold": true }
+            "ul": [
+              { "text": "{{ulbType}}", "bold": true,"listType": "none" },
+              { "text": "{{logo-header}}", "bold": true,"listType": "none" }
             ],
             "alignment": "right",
-            "margin": [0, 0, -10, 0]
+            "margin": [0, 0, -2, 0]
           }
         ]
       },
@@ -368,7 +369,7 @@
         "fontSize": 10,
         "color": "#000000",
         "alignment": "right",
-        "margin": [0, 6, 35, 6]
+        "margin": [0, 6, 4, 6]
       },
       "receipt-total-label": {
         "fontSize": 10,
@@ -381,7 +382,7 @@
         "color": "#000000",
         "bold": true,
         "alignment": "right",
-        "margin": [0, 6, 35, 6]
+        "margin": [0, 6, 4, 6]
       },
       "receipt-approver": {
         "fontSize": 10,

--- a/configs/pdf-service/format-config/bpa-receiptsecond.json
+++ b/configs/pdf-service/format-config/bpa-receiptsecond.json
@@ -230,7 +230,7 @@
                 "text": "Amount (In ₹)",
                 "style": "receipt-header",
                 "alignment": "right",
-                "margin": [0, 0, 35, 0],
+                "margin": [0, 0, 4, 0],
                 "bold": true
               }
             ],
@@ -419,11 +419,12 @@
             "alignment": "left"
           },
           {
-            "text": [
-              { "text": "{{ulbType}} {{logo-header}}", "bold": true }
+            "ul": [
+              { "text": "{{ulbType}}", "bold": true,"listType": "none" },
+              { "text": "{{logo-header}}", "bold": true,"listType": "none" }
             ],
             "alignment": "right",
-            "margin": [0, 0, -10, 0]
+            "margin": [0, 0, -2, 0]
           }
         ]
       },
@@ -501,20 +502,20 @@
         "fontSize": 10,
         "color": "#000000",
         "alignment": "right",
-        "margin": [0, 0, 35, 0]
+        "margin": [0, 0, 4, 0]
       },
       "receipt-total-label": {
         "fontSize": 10,
         "color": "#000000",
         "bold": true,
-        "margin": [4, 0, 35, 0]
+        "margin": [4, 0, 4, 0]
       },
       "receipt-total-value": {
         "fontSize": 10,
         "color": "#000000",
         "bold": true,
         "alignment": "right",
-        "margin": [0, 2, 35, 2]
+        "margin": [0, 2, 4, 2]
       },
       "receipt-approver": {
         "fontSize": 10,

--- a/configs/pdf-service/format-config/challan-notice.json
+++ b/configs/pdf-service/format-config/challan-notice.json
@@ -31,23 +31,29 @@
                   {
                     "style": "noc-head",
                     "table": {
-                      "widths": ["*"],
+                      "widths": [90, "*", 90],
                       "body": [
                         [
                           {
+                            "image": "{{logoImage}}",
+                            "width": 65,
+                            "height": 65,
+                            "alignment": "left",
+                            "margin": [0, 3, 0, 5]
+                          },
+                          {
                             "stack": [
                               {
-                                "image": "{{logoImage}}",
-                                "width": 61.25,
-                                "height": 61.25
-                              },
-                              {
                                 "text": "{{ulbType}} {{logo-header}}",
-                                "style": "receipt-logo-header"
+                                "style": "receipt-logo-header",
+                                "alignment": "center",
+                                "margin": [0, 9, 0, 5]
                               },
                               {
                                 "text": "E-CHALLAN NOTICE",
-                                "style": "receipt-logo-sub-header"
+                                "style": "receipt-logo-sub-header",
+                                "alignment": "center",
+                                "margin": [0, 5, 0, 0]
                               },
                               {
                                 "style": "receipt-logo-sub-header",
@@ -56,8 +62,14 @@
                                 "text": "(Computer Generated - No Signature Required)"
                               }
                             ],
-                            "alignment": "center",
-                            "margin": [0, 10, 0, 0]
+                            "alignment": "center"
+                          },
+                          {
+                            "image": "{{qrcodeimage}}",
+                            "width": 72,
+                            "height": 72,
+                            "alignment": "right",
+                            "margin": [0, 0, 0, 0]
                           }
                         ]
                       ]
@@ -123,24 +135,10 @@
                             "style": "receipt-table-value"
                           },
                           {
-                            "text": "{{paymentDate}} , {{violationTimeIST}}",
+                            "text": "{{violationDate}} , {{epochIST}}",
                             "border": [false, false, false, false],
                             "style": "receipt-table",
                             "font": "Roboto"
-                          }
-                        ],
-                        [
-                          {
-                            "text": "Qr Code",
-                            "border": [false, false, false, true],
-                            "style": "receipt-table-value"
-                          },
-                          {
-                            "image": "{{qrcodeimage}}",
-                            "style": "receipt-table",
-                            "border": [false, false, false, true],
-                            "width": 60,
-                            "height": 60
                           }
                         ]
                       ]
@@ -155,12 +153,12 @@
                         [
                           {
                             "text": "VIOLATOR DETAILS",
-                            "border": [false, false, false, false],
+                            "border": [false, true, false, false],
                             "style": "receipt-table-value"
                           },
                           {
                             "text": " ",
-                            "border": [false, false, false, false],
+                            "border": [false, true, false, false],
                             "style": "receipt-table",
                             "font": "Roboto"
                           }
@@ -172,7 +170,7 @@
                   {
                     "style": "next-noc-table",
                     "table": {
-                      "widths": ["26%", "74%"],
+                      "widths": ["30%", "70%"],
                       "body": [
                         [
                           {
@@ -211,19 +209,6 @@
                             "style": "receipt-table",
                             "font": "Roboto"
                           }
-                        ],
-                        [
-                          {
-                            "text": "Email",
-                            "border": [false, false, false, true],
-                            "style": "receipt-table-value"
-                          },
-                          {
-                            "text": "{{ownerEmail}}",
-                            "border": [false, false, false, true],
-                            "style": "receipt-table",
-                            "font": "Roboto"
-                          }
                         ]
                       ]
                     },
@@ -237,12 +222,12 @@
                         [
                           {
                             "text": "VIOLATION DETAILS",
-                            "border": [false, false, false, false],
+                            "border": [false, true, false, false],
                             "style": "receipt-table-value"
                           },
                           {
                             "text": " ",
-                            "border": [false, false, false, false],
+                            "border": [false, true, false, false],
                             "style": "receipt-table",
                             "font": "Roboto"
                           }
@@ -254,7 +239,7 @@
                   {
                     "style": "next-noc-table",
                     "table": {
-                      "widths": ["26%", "74%"],
+                      "widths": ["30%", "70%"],
                       "body": [
                         [
                           {
@@ -275,7 +260,7 @@
                             "style": "receipt-table-value"
                           },
                           {
-                            "text": "{{location}}",
+                            "text": "{{latitude}}, {{longitude}}",
                             "border": [false, false, false, false],
                             "style": "receipt-table",
                             "font": "Roboto"
@@ -288,7 +273,7 @@
                             "style": "receipt-table-value"
                           },
                           {
-                            "text": "{{violationDate}} , {{violationTimeIST}}",
+                            "text": "{{violationDate}} , {{epochIST}}",
                             "border": [false, false, false, false],
                             "style": "receipt-table",
                             "font": "Roboto"
@@ -332,12 +317,12 @@
                         [
                           {
                             "text": "PENALTY DETAILS",
-                            "border": [false, false, false, false],
+                            "border": [false, true, false, false],
                             "style": "receipt-table-value"
                           },
                           {
                             "text": " ",
-                            "border": [false, false, false, false],
+                            "border": [false, true, false, false],
                             "style": "receipt-table",
                             "font": "Roboto"
                           }
@@ -365,42 +350,14 @@
                         ],
                         [
                           {
-                            "text": "Challan Fine",
-                            "border": [false, false, false, false],
-                            "bold": true,
-                            "style": "receipt-table-value"
-                          },
-                          {
-                            "text": "Rs {{challanFine}}",
-                            "border": [false, false, false, false],
-                            "bold": true,
-                            "style": "receipt-table"
-                          }
-                        ],
-                        [
-                          {
-                            "text": "Challan Amount",
-                            "border": [false, false, false, false],
-                            "bold": true,
-                            "style": "receipt-table-value"
-                          },
-                          {
-                            "text": " Rs {{challanAmount}}",
-                            "border": [false, false, false, false],
-                            "bold": true,
-                            "style": "receipt-table"
-                          }
-                        ],
-                        [
-                          {
                             "text": "Total Amount Collected (in Rs)",
-                            "border": [false, false, false, false],
+                            "border": [false, false, false, true],
                             "bold": true,
                             "style": "receipt-table-value"
                           },
                           {
                             "text": "{{TotalChallanAmount}}",
-                            "border": [false, false, false, false],
+                            "border": [false, false, false, true],
                             "bold": true,
                             "style": "receipt-table"
                           }
@@ -408,13 +365,13 @@
                         [
                           {
                             "text": "Due Date for Payment",
-                            "border": [false, false, false, true],
+                            "border": [false, false, false, false],
                             "bold": true,
                             "style": "receipt-table-value"
                           },
                           {
-                            "text": "{{dueDate}}",
-                            "border": [false, false, false, true],
+                            "text": "{{violationDate}}",
+                            "border": [false, false, false, false],
                             "bold": true,
                             "style": "receipt-table"
                           }
@@ -517,20 +474,20 @@
                             "style": "receipt-table-value-down",
                             "alignment": "left",
                             "border": [false, false, false, false],
-                            "margin": [0, 0, 0, 0]
+                            "margin": [4, 0, 0, 0]
                           }
                         ],
                         [
                           {
                             "stack": [
                               {
-                                "text": "1. Scan the QR Code above with any UPI app"
+                                "text": "1. {{challan_notice_1}}"
                               },
                               {
-                                "text": "2. Pay online via M-Seva App under 'Challan Payment' section"
+                                "text": "2. {{challan_notice_2}}"
                               },
                               {
-                                "text": "3. Visit designated MCL Counters with this Challan Number"
+                                "text": "3. {{challan_notice_3}}"
                               }
                             ],
                             "style": "receipt-table",
@@ -555,7 +512,7 @@
                             "style": "receipt-table-value-down",
                             "alignment": "left",
                             "border": [false, false, false, false],
-                            "margin": [0, 0, 0, 0]
+                            "margin": [4, 0, 0, 0]
                           }
                         ],
                         [
@@ -602,7 +559,7 @@
         "fontSize": 11,
         "bold": true,
         "letterSpacing": 0.74,
-        "margin": [0, 0, 0, 2]
+        "margin": [0, 2, 0, 2]
       },
       "receipt-logo-sub-header": {
         "color": "#000000",
@@ -653,7 +610,7 @@
       },
       "no-signature": {
         "fontSize": 9,
-        "margin": [0, 2, 0, 0],
+        "margin": [0, 200, 0, 0],
         "color": "#484848"
       },
       "pt-disclaimer": {

--- a/configs/pdf-service/format-config/challan-notice.json
+++ b/configs/pdf-service/format-config/challan-notice.json
@@ -82,33 +82,7 @@
                     },
                     "layout": "noBorders"
                   },
-                  {
-                    "style": "next-noc-table",
-                    "table": {
-                      "widths": ["30%", "70%"],
-                      "body": [
-                        [
-                          {
-                            "text": "Field",
-                            "border": [true, true, true, true],
-                             "fontSize": 13,
-                             "fillColor": "#d1d1d1",
-                            "style": "receipt-table-value"
-                          },
-                          {
-                            "text": "Details",
-                            "border": [true, true, true, true],
-                             "fontSize": 13,
-                             "fillColor": "#d1d1d1",
-                            "style": "receipt-table-value",
-                            "font": "Roboto"
-                          }
-                        ]
-                      ],
-                      "margin":[0, 5, 0, 1]
-                    },
-                    "layout": {}
-                  },
+                  
                   {
                     "style": "next-noc-table",
                     "table": {

--- a/configs/pdf-service/format-config/challan-notice.json
+++ b/configs/pdf-service/format-config/challan-notice.json
@@ -50,16 +50,22 @@
                                 "margin": [0, 9, 0, 5]
                               },
                               {
-                                "text": "E-CHALLAN NOTICE",
-                                "style": "receipt-logo-sub-header",
+                                "stack": [
+                                  { "text": "{{address}}" },
+                                  { "text": "{{website}}" },
+                                  { "text": "{{email}}" },
+                                  { "text": "{{phoneNumber}}" }
+                                ],
                                 "alignment": "center",
-                                "margin": [0, 5, 0, 0]
+                                "color": "#484848",
+                                "margin": [0, 2, 0, 2]
                               },
                               {
+                                "text": "E-CHALLAN NOTICE",
                                 "style": "receipt-logo-sub-header",
-                                "font": "Cambay",
-                                "italics": true,
-                                "text": "(Computer Generated - No Signature Required)"
+                                "fontSize": 13,
+                                "alignment": "center",
+                                "margin": [0, 5, 0, 0]
                               }
                             ],
                             "alignment": "center"
@@ -83,18 +89,23 @@
                       "body": [
                         [
                           {
-                            "text": "CHALLAN INFORMATION",
-                            "border": [false, true, false, false],
+                            "text": "Field",
+                            "border": [true, true, true, true],
+                             "fontSize": 13,
+                             "fillColor": "#d1d1d1",
                             "style": "receipt-table-value"
                           },
                           {
-                            "text": " ",
-                            "border": [false, true, false, false],
-                            "style": "receipt-table",
+                            "text": "Details",
+                            "border": [true, true, true, true],
+                             "fontSize": 13,
+                             "fillColor": "#d1d1d1",
+                            "style": "receipt-table-value",
                             "font": "Roboto"
                           }
                         ]
-                      ]
+                      ],
+                      "margin":[0, 5, 0, 1]
                     },
                     "layout": {}
                   },
@@ -105,25 +116,26 @@
                       "body": [
                         [
                           {
-                            "text": "Field",
-                            "border": [false, false, false, false],
-                            "style": "receipt-table-value"
+                            "text": "Challan Information",
+                            "style": "receipt-table-value",
+                            "fontSize": 12,
+                            "fillColor": "#d1d1d1",
+                            "border": [true, true, false, false]
                           },
                           {
-                            "text": "Details",
-                            "border": [false, false, false, false],
-                            "style": "receipt-table-value"
+                            "text": " ",
+                            "fillColor": "#d1d1d1",
+                            "border": [false, true, true, false],
+                            "style": "receipt-table"
                           }
                         ],
                         [
                           {
                             "text": "Challan Number",
-                            "border": [false, false, false, false],
                             "style": "receipt-table-value"
                           },
                           {
                             "text": "{{consumerID}}",
-                            "border": [false, false, false, false],
                             "style": "receipt-table",
                             "font": "Roboto"
                           }
@@ -131,12 +143,10 @@
                         [
                           {
                             "text": "Issue Date & Time",
-                            "border": [false, false, false, false],
                             "style": "receipt-table-value"
                           },
                           {
                             "text": "{{violationDate}} , {{epochIST}}",
-                            "border": [false, false, false, false],
                             "style": "receipt-table",
                             "font": "Roboto"
                           }
@@ -152,15 +162,18 @@
                       "body": [
                         [
                           {
-                            "text": "VIOLATOR DETAILS",
-                            "border": [false, true, false, false],
-                            "style": "receipt-table-value"
+                            "text": "Violator Details",
+                            "style": "receipt-table-value",
+                            "fillColor": "#d1d1d1",
+                            "border": [true, true, false, true],
+                             "fontSize": 12
                           },
                           {
                             "text": " ",
-                            "border": [false, true, false, false],
                             "style": "receipt-table",
-                            "font": "Roboto"
+                            "fillColor": "#d1d1d1",
+                            "font": "Roboto",
+                            "border": [false, true, true, true]
                           }
                         ]
                       ]
@@ -172,27 +185,14 @@
                     "table": {
                       "widths": ["30%", "70%"],
                       "body": [
-                        [
-                          {
-                            "text": "Field",
-                            "border": [false, false, false, false],
-                            "style": "receipt-table-value"
-                          },
-                          {
-                            "text": "Details",
-                            "border": [false, false, false, false],
-                            "style": "receipt-table-value"
-                          }
-                        ],
+                        
                         [
                           {
                             "text": "Name",
-                            "border": [false, false, false, false],
                             "style": "receipt-table-value"
                           },
                           {
                             "text": "{{payerName}}",
-                            "border": [false, false, false, false],
                             "style": "receipt-table",
                             "font": "Roboto"
                           }
@@ -200,12 +200,10 @@
                         [
                           {
                             "text": "Payer Contact",
-                            "border": [false, false, false, false],
                             "style": "receipt-table-value"
                           },
                           {
                             "text": "{{payerContact}}",
-                            "border": [false, false, false, false],
                             "style": "receipt-table",
                             "font": "Roboto"
                           }
@@ -221,15 +219,18 @@
                       "body": [
                         [
                           {
-                            "text": "VIOLATION DETAILS",
-                            "border": [false, true, false, false],
-                            "style": "receipt-table-value"
+                            "text": "Violation Details",
+                            "style": "receipt-table-value",
+                            "fillColor": "#d1d1d1",
+                            "border": [true, true, false, true],
+                             "fontSize": 12
                           },
                           {
                             "text": " ",
-                            "border": [false, true, false, false],
                             "style": "receipt-table",
-                            "font": "Roboto"
+                            "fillColor": "#d1d1d1",
+                            "font": "Roboto",
+                            "border": [false, true, true, true]
                           }
                         ]
                       ]
@@ -241,27 +242,14 @@
                     "table": {
                       "widths": ["30%", "70%"],
                       "body": [
-                        [
-                          {
-                            "text": "Field",
-                            "border": [false, false, false, false],
-                            "style": "receipt-table-value"
-                          },
-                          {
-                            "text": "Details",
-                            "border": [false, false, false, false],
-                            "style": "receipt-table-value"
-                          }
-                        ],
+                        
                         [
                           {
                             "text": "Location of Violation",
-                            "border": [false, false, false, false],
                             "style": "receipt-table-value"
                           },
                           {
                             "text": "{{latitude}}, {{longitude}}",
-                            "border": [false, false, false, false],
                             "style": "receipt-table",
                             "font": "Roboto"
                           }
@@ -269,12 +257,10 @@
                         [
                           {
                             "text": "Violation Date & Time",
-                            "border": [false, false, false, false],
                             "style": "receipt-table-value"
                           },
                           {
                             "text": "{{violationDate}} , {{epochIST}}",
-                            "border": [false, false, false, false],
                             "style": "receipt-table",
                             "font": "Roboto"
                           }
@@ -282,12 +268,10 @@
                         [
                           {
                             "text": "Offence Category",
-                            "border": [false, false, false, false],
                             "style": "receipt-table-value"
                           },
                           {
                             "text": "{{offenceCategoryName}}",
-                            "border": [false, false, false, false],
                             "style": "receipt-table",
                             "font": "Roboto"
                           }
@@ -295,12 +279,10 @@
                         [
                           {
                             "text": "Specific Offence",
-                            "border": [false, false, false, false],
                             "style": "receipt-table-value"
                           },
                           {
                             "text": "{{offenceTypeName}} / {{offenceCategoryName}} / {{offenceSubCategoryName}}",
-                            "border": [false, false, false, false],
                             "style": "receipt-table",
                             "font": "Roboto"
                           }
@@ -316,14 +298,17 @@
                       "body": [
                         [
                           {
-                            "text": "PENALTY DETAILS",
-                            "border": [false, true, false, false],
-                            "style": "receipt-table-value"
+                            "text": "Penalty Details",
+                            "style": "receipt-table-value",
+                            "fillColor": "#d1d1d1",
+                            "border": [true, true, false, true],
+                             "fontSize": 12
                           },
                           {
                             "text": " ",
-                            "border": [false, true, false, false],
                             "style": "receipt-table",
+                            "fillColor": "#d1d1d1",
+                            "border": [false, true, true, true],
                             "font": "Roboto"
                           }
                         ]
@@ -336,28 +321,15 @@
                     "table": {
                       "widths": ["30%", "70%"],
                       "body": [
-                        [
-                          {
-                            "text": "Field",
-                            "border": [false, false, false, false],
-                            "style": "receipt-table-value"
-                          },
-                          {
-                            "text": "Details",
-                            "border": [false, false, false, false],
-                            "style": "receipt-table-value"
-                          }
-                        ],
+                        
                         [
                           {
                             "text": "Total Amount Collected (in Rs)",
-                            "border": [false, false, false, true],
                             "bold": true,
                             "style": "receipt-table-value"
                           },
                           {
                             "text": "{{TotalChallanAmount}}",
-                            "border": [false, false, false, true],
                             "bold": true,
                             "style": "receipt-table"
                           }
@@ -365,13 +337,11 @@
                         [
                           {
                             "text": "Due Date for Payment",
-                            "border": [false, false, false, false],
                             "bold": true,
                             "style": "receipt-table-value"
                           },
                           {
                             "text": "{{violationDate}}",
-                            "border": [false, false, false, false],
                             "bold": true,
                             "style": "receipt-table"
                           }
@@ -387,14 +357,17 @@
                       "body": [
                         [
                           {
-                            "text": "ISSUING OFFICER",
-                            "border": [false, false, false, false],
-                            "style": "receipt-table-value"
+                            "text": "Issuing Officer",
+                            "style": "receipt-table-value",
+                            "fillColor": "#d1d1d1",
+                            "border": [true, true, false, true],
+                             "fontSize": 12
                           },
                           {
                             "text": " ",
-                            "border": [false, false, false, false],
                             "style": "receipt-table",
+                            "fillColor": "#d1d1d1",
+                            "border": [false, true, true, true],
                             "font": "Roboto"
                           }
                         ]
@@ -407,54 +380,43 @@
                     "table": {
                       "widths": ["30%", "70%"],
                       "body": [
-                        [
-                          {
-                            "text": "Field",
-                            "border": [false, false, false, false],
-                            "style": "receipt-table-value"
-                          },
-                          {
-                            "text": "Details",
-                            "border": [false, false, false, false],
-                            "style": "receipt-table-value"
-                          }
-                        ],
+                        
                         [
                           {
                             "text": "Name & ID",
-                            "border": [false, false, false, false],
+                             
                             "bold": true,
                             "style": "receipt-table-value"
                           },
                           {
                             "text": "{{officerName}} ({{officerCode}}) ({{officerID}})",
-                            "border": [false, false, false, false],
+                             
                             "style": "receipt-table"
                           }
                         ],
                         [
                           {
                             "text": "Department",
-                            "border": [false, false, false, false],
+                             
                             "bold": true,
                             "style": "receipt-table-value"
                           },
                           {
                             "text": "{{officerdept}}",
-                            "border": [false, false, false, false],
+                             
                             "style": "receipt-table"
                           }
                         ],
                         [
                           {
                             "text": "Digital Signature",
-                            "border": [false, false, false, true],
+                             
                             "bold": true,
                             "style": "receipt-table-value"
                           },
                           {
                             "text": "{{officerName}}",
-                            "border": [false, false, false, true],
+                             
                             "style": "receipt-table"
                           }
                         ]
@@ -469,11 +431,11 @@
                       "body": [
                         [
                           {
-                            "text": "PAYMENT INSTRUCTIONS",
+                            "text": "Payment Instructions",
                             "bold": true,
                             "style": "receipt-table-value-down",
                             "alignment": "left",
-                            "border": [false, false, false, false],
+                             
                             "margin": [4, 0, 0, 0]
                           }
                         ],
@@ -492,7 +454,7 @@
                             ],
                             "style": "receipt-table",
                             "alignment": "left",
-                            "border": [false, false, false, false],
+                             
                             "margin": [10, 2, 10, 2]
                           }
                         ]
@@ -511,7 +473,7 @@
                             "bold": true,
                             "style": "receipt-table-value-down",
                             "alignment": "left",
-                            "border": [false, false, false, false],
+                             
                             "margin": [4, 0, 0, 0]
                           }
                         ],
@@ -529,7 +491,7 @@
                             ],
                             "style": "receipt-table",
                             "alignment": "left",
-                            "border": [false, false, false, true],
+                             
                             "margin": [10, 0, 10, 0]
                           }
                         ]
@@ -539,7 +501,7 @@
                   },
                   {
                     "style": "no-signature",
-                    "text": "{{no_signature}}",
+                    "text": "This is Computer generated notice, Signature is not required",
                     "alignment": "center"
                   }
                 ]
@@ -552,7 +514,7 @@
     ],
     "styles": {
       "noc-head": {
-        "margin": [0, -30, 0, 1]
+        "margin": [0, -30, 0, 10]
       },
       "receipt-logo-header": {
         "color": "#000000",
@@ -586,21 +548,21 @@
       "next-noc-table": {
         "fontSize": 9,
         "color": "#000000",
-        "margin": [-25, 0, -22, 0]
+        "margin": [0, 2, 0, 5]
       },
       "receipt-table-value": {
         "color": "#000000",
         "bold": true,
         "fontSize": 9,
         "fontWeight": 500,
-        "margin": [3, 0, 2, 0]
+        "margin": [3, 2, 2, 2]
       },
       "receipt-table": {
         "color": "#000000",
         "bold": false,
         "fontSize": 9,
         "fontWeight": 400,
-        "margin": [3, 0, 0, 0]
+        "margin": [3, 2, 0, 2]
       },
       "receipt-approver": {
         "fontSize": 9,
@@ -610,7 +572,7 @@
       },
       "no-signature": {
         "fontSize": 9,
-        "margin": [0, 200, 0, 0],
+        "margin": [0, 55, 0, 0],
         "color": "#484848"
       },
       "pt-disclaimer": {

--- a/configs/pdf-service/format-config/challangeneration-receipt.json
+++ b/configs/pdf-service/format-config/challangeneration-receipt.json
@@ -193,30 +193,6 @@
         "table": {
           "widths": ["70%", "30%"],
           "body": [
-            [
-              {
-                "text": "Challan Fee",
-                "border": [true, true, false, false],
-                "style": "receipt-table-value-down"
-              },
-              {
-                "text": "₹{{challanFee}}",
-                "border": [false, true, true, false],
-                "style": "receipt-table-value-down"
-              }
-            ],
-            [
-              {
-                "text": "Challan Amount",
-                "border": [true, false, false, false],
-                "style": "receipt-table-value-down"
-              },
-              {
-                "text": "₹{{challanAmount}}",
-                "border": [false, false, true, false],
-                "style": "receipt-table-value-down"
-              }
-            ],
 
             [
               {

--- a/configs/pdf-service/format-config/challangeneration-receipt.json
+++ b/configs/pdf-service/format-config/challangeneration-receipt.json
@@ -216,7 +216,7 @@
         "style": "pt-disclaimer",
         "stack": [
           {
-            "text": "IMPORTANT NOTES",
+            "text": "Important Notes",
             "bold": true,
             "style": "pt-disclaimer-header"
           },

--- a/configs/pdf-service/format-config/chb-permissionletter.json
+++ b/configs/pdf-service/format-config/chb-permissionletter.json
@@ -67,7 +67,7 @@
               {
                 "stack": [
                   { "text": "To,", "margin": [0, 0, 0, 0] },
-                  { "text": "{{payerName}}", "margin": [10, 0, 0, 0] },
+                  { "text": "{{applicantName}}", "margin": [10, 0, 0, 0] },
                   { "text": "{{payerAddress}}", "margin": [10, 0, 0, 0] }
                 ],
                 "style": "receipt-table",
@@ -104,7 +104,7 @@
                     "bold": true
                   },
                   {
-                    "text": "Dear {{payerName}},",
+                    "text": "Dear {{applicantName}},",
                     "style": "receipt-table",
                     "alignment": "left",
                     "margin": [0, 0, 0, 0]

--- a/configs/pdf-service/format-config/chbservice-receipt.json
+++ b/configs/pdf-service/format-config/chbservice-receipt.json
@@ -103,7 +103,7 @@
                 "style": "receipt-table-value"
               },
               {
-                "text": "{{payerName}}",
+                "text": "{{applicantName}}",
                 "border": [false, false, true, false],
                 "style": "receipt-table"
               }
@@ -115,7 +115,7 @@
                 "style": "receipt-table-value"
               },
               {
-                "text": "{{payerContact}}",
+                "text": "{{applicantMobileNo}}",
                 "border": [false, false, false, true],
                 "style": "receipt-table"
               },


### PR DESCRIPTION
**challangeneration-receipt **  Issues fixed : The bigger amount out of challan fine and amount shown on the receipt and in fee breakdown only one fee detail kept _(as asked by deepika mam)_

**challan-notice :** Issues fixed :

1. The bigger amount out of challan fine and amount shown on the receipt and in fee breakdown only one fee detail kept , latitude and longitude displayed, email field removed, incorrect time coming, corrected and payment instructions localised to show in punjabi (as asked by deepika mam) , 

2. Position of qr and logo changed as coming in other receipt _(as asked by sagar sir)_


**bpa-receipt** (professional registration), **bpa-obps-receipt** (pay1) , **bpa-receipt-second** (pay2) -:

1. Issues fixed : amount and fee breakdown values right aligned and ulb name shifted under ulbtype _(as asked by balpreet sir)_ 
[challan-notice-updated.pdf](https://github.com/user-attachments/files/23743520/challan-notice-updated.pdf)
[challangeneration-receipt.pdf](https://github.com/user-attachments/files/23743523/challangeneration-receipt.pdf)
[bpa-receipt(professional_registration).pdf](https://github.com/user-attachments/files/23743525/bpa-receipt.professional_registration.pdf)
[bpa-receipt(pay1).pdf](https://github.com/user-attachments/files/23743527/bpa-receipt.pay1.pdf)
[bpa-receipt-second(pay2).pdf](https://github.com/user-attachments/files/23743528/bpa-receipt-second.pay2.pdf)
