### PR TITLE
pet receipt and certificate changes and challan changes

### DIFF
--- a/configs/pdf-service/data-config/pet-receipt-employee.json
+++ b/configs/pdf-service/data-config/pet-receipt-employee.json
@@ -231,13 +231,7 @@
                 },
                 "type": "date"
               },
-              {
-                "variable": "ReceiptDate",
-                "value": {
-                  "path": "$.paymentDetails[0].receiptDate"
-                },
-                "type": "date"
-              }, {
+               {
                 "variable": "bankName",
                 "value": {
                   "path": "$.additionalDetails[0].bankName"

--- a/configs/pdf-service/data-config/petcertificatenew.json
+++ b/configs/pdf-service/data-config/petcertificatenew.json
@@ -361,7 +361,7 @@
               {
                 "variable": "validityDateEpoch",
                 "value": {
-                  "path": "$.application.auditDetails.lastModifiedTime"
+                  "path": "$.application.validityDate"
                 }
               },
               {
@@ -848,9 +848,13 @@
                 "format": "DD MMMM, YYYY"
               },
               {
+                "variable": "validityDateFixedEpoch",
+                "formula": "{{validityDateEpoch}}*1000"
+              },
+              {
                 "variable": "validityDate",
                 "type": "date",
-                "formula": "{{validityDateEpoch}}",
+                "formula": "{{validityDateFixedEpoch}}",
                 "timezone": "Asia/Kolkata",
                 "format": "DD MMMM, YYYY"
               },

--- a/configs/pdf-service/format-config/challan-notice.json
+++ b/configs/pdf-service/format-config/challan-notice.json
@@ -47,7 +47,8 @@
                                 "text": "{{ulbType}} {{logo-header}}",
                                 "style": "receipt-logo-header",
                                 "alignment": "center",
-                                "margin": [0, 9, 0, 5]
+                                "margin": [0, 9, 0, 5],
+                                "fontSize": 12
                               },
                               {
                                 "stack": [

--- a/configs/pdf-service/format-config/pet-receipt-employee.json
+++ b/configs/pdf-service/format-config/pet-receipt-employee.json
@@ -128,7 +128,7 @@
                 "style": "receipt-table-value"
               },
               {
-                "text": "{{ReceiptDate}}",
+                "text": "{{receiptDate}}",
                 "border": [
                   false,
                   false,
@@ -692,7 +692,7 @@
                 "style": "receipt-table-value"
               },
               {
-                "text": "{{ReceiptDate}}",
+                "text": "{{receiptDate}}",
                 "border": [
                   false,
                   false,

--- a/configs/pdf-service/format-config/petcertificatenew.json
+++ b/configs/pdf-service/format-config/petcertificatenew.json
@@ -406,7 +406,7 @@
                   "{{pet_new_term_16}}"
                 ],
                 "style": "receipt-table",
-                "fontSize": 7,
+                "fontSize": 9,
                 "alignment": "justify",
                 "border": [false, false, false, false],
                 "margin": [0, 0, 0, 0]


### PR DESCRIPTION
[PMIDC New Services](https://punjabemunicipalityissues.lgpunjab.gov.in/browse/PNS)[PNS-2296](https://punjabemunicipalityissues.lgpunjab.gov.in/browse/PNS-2296)

[PNS-2299](https://punjabemunicipalityissues.lgpunjab.gov.in/browse/PNS-2299)
Validity date is incorrectly showing today’s date instead of 31-03-2027 and font should be large

changes made in data config and format config of pdf service 
mappings for validity date and address added in pet receipts for employee and citizen and pet certificate


Challan notice heading font size enlarged as per feedback